### PR TITLE
Add sponsor request and giveaway helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
                     <a href="#search" class="nav-link">Search</a>
                     <a href="#favorites" class="nav-link">Favorites</a>
                     <a href="#about" class="nav-link">About</a>
+                    <a href="#sponsor" class="nav-link">Sponsor Finder</a>
                     <a href="#gofundme" class="nav-link">GoFundMe</a>
                     <a href="#ai-promotion" class="nav-link">AI Promotion</a>
                 </div>
@@ -128,6 +129,28 @@
                         <li>Be cautious of scams and too-good-to-be-true offers</li>
                         <li>Read community rules before participating</li>
                     </ul>
+                </div>
+            </div>
+        </section>
+        <section id="sponsor" class="sponsor-section hidden">
+            <div class="container">
+                <h3>Request a Sponsor</h3>
+                <p>Enter what you need and we'll suggest a sponsor and message to ask for help. We'll also show some current giveaways you can enter.</p>
+                <form id="sponsor-form" class="sponsor-form">
+                    <input type="text" id="request-input" placeholder="Describe your request" required>
+                    <button type="submit" class="btn btn-primary"><i class="fas fa-hands-helping"></i> Find Sponsor</button>
+                </form>
+                <div id="sponsor-result" class="hidden">
+                    <h4 id="sponsor-name"></h4>
+                    <p id="draft-message" class="sponsor-message"></p>
+                </div>
+                <div id="giveaways" class="hidden">
+                    <h4>Free Giveaways</h4>
+                    <ul id="giveaway-list"></ul>
+                    <div id="giveaway-entry" class="hidden">
+                        <input type="text" id="giveaway-name" placeholder="Your name">
+                        <button type="button" id="enter-giveaway" class="btn btn-outline">Enter to Win</button>
+                    </div>
                 </div>
             </div>
         </section>

--- a/script.js
+++ b/script.js
@@ -163,6 +163,29 @@ const resultsContainer = document.getElementById('results-list');
 const loadingElement = document.querySelector('.loading');
 const favoritesSection = document.getElementById('favorites');
 const favoritesList = document.getElementById('favorites-list');
+const sponsorForm = document.getElementById('sponsor-form');
+const requestInput = document.getElementById('request-input');
+const sponsorNameEl = document.getElementById('sponsor-name');
+const draftMessageEl = document.getElementById('draft-message');
+const sponsorResult = document.getElementById('sponsor-result');
+const giveawaysSection = document.getElementById('giveaways');
+const giveawayList = document.getElementById('giveaway-list');
+const giveawayEntry = document.getElementById('giveaway-entry');
+const giveawayName = document.getElementById('giveaway-name');
+const enterGiveawayBtn = document.getElementById('enter-giveaway');
+
+// Sample sponsors and giveaways
+const sponsors = [
+    { name: "Helping Hands Foundation", keywords: ["general", "bills", "emergency"] },
+    { name: "Food For All", keywords: ["food", "groceries"] },
+    { name: "WarmHome Charity", keywords: ["rent", "housing", "utilities"] }
+];
+
+const giveaways = [
+    { title: "Grocery Gift Card Giveaway", link: "https://example.com/grocery-giveaway" },
+    { title: "Utility Bill Raffle", link: "https://example.com/utility-raffle" },
+    { title: "Community Care Package", link: "https://example.com/care-package" }
+];
 
 // Initialize application
 document.addEventListener('DOMContentLoaded', function() {
@@ -267,6 +290,37 @@ function setupEventListeners() {
                 location: "Chicago, IL"
             };
             displayGoFundMeResults([aiFundraiser, ...gofundmeFundraisers]);
+        });
+    }
+
+    // Sponsor request functionality
+    if (sponsorForm) {
+        sponsorForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const request = requestInput.value.trim();
+            if (!request) return;
+            const sponsor = findSponsor(request);
+            sponsorNameEl.textContent = sponsor.name;
+            draftMessageEl.textContent = generateMessage(request, sponsor);
+            sponsorResult.classList.remove('hidden');
+
+            // populate giveaways
+            giveawayList.innerHTML = '';
+            giveaways.forEach(g => {
+                const li = document.createElement('li');
+                li.innerHTML = `<a href="${g.link}" target="_blank">${g.title}</a>`;
+                giveawayList.appendChild(li);
+            });
+            giveawaysSection.classList.remove('hidden');
+            giveawayEntry.classList.remove('hidden');
+        });
+    }
+
+    if (enterGiveawayBtn) {
+        enterGiveawayBtn.addEventListener('click', () => {
+            const name = giveawayName.value.trim();
+            if (!name) return;
+            giveawayEntry.innerHTML = `<p>Thanks, ${name}! You're entered for a chance to win.</p>`;
         });
     }
 }
@@ -555,6 +609,16 @@ function showApplyModal() {
     `;
     document.body.appendChild(modal);
     document.getElementById('close-modal').onclick = () => modal.remove();
+}
+
+// Sponsor helper functions
+function findSponsor(request) {
+    const lower = request.toLowerCase();
+    return sponsors.find(s => s.keywords.some(k => lower.includes(k))) || sponsors[Math.floor(Math.random() * sponsors.length)];
+}
+
+function generateMessage(request, sponsor) {
+    return `Hi ${sponsor.name}, I am reaching out because ${request}. Any assistance would be greatly appreciated. Thank you!`;
 }
 
 // Utility functions

--- a/style.css
+++ b/style.css
@@ -549,14 +549,14 @@ body.dark-mode .dark-mode-toggle {
 }
 
 /* GoFundMe and AI Promotion Sections */
-.gofundme-section, .ai-promotion-section {
+.gofundme-section, .ai-promotion-section, .sponsor-section {
     padding: 100px 0 60px 0; /* Add extra top padding to clear the fixed header */
     background: var(--card-bg);
     backdrop-filter: var(--glass-blur);
     box-shadow: var(--shadow);
     margin-bottom: 40px;
 }
-.gofundme-section h3, .ai-promotion-section h3 {
+.gofundme-section h3, .ai-promotion-section h3, .sponsor-section h3 {
     font-size: 2rem;
     margin-bottom: 30px;
     color: #333;
@@ -577,6 +577,44 @@ body.dark-mode .dark-mode-toggle {
 }
 #gfm-results-list {
     margin-top: 20px;
+}
+
+/* Sponsor Finder */
+.sponsor-form {
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+    margin-bottom: 30px;
+    justify-content: center;
+}
+
+#request-input {
+    flex: 1;
+    padding: 12px 18px;
+    border-radius: 30px;
+    border: 1px solid #ddd;
+    font-size: 1rem;
+    min-width: 220px;
+}
+
+#sponsor-result, #giveaways {
+    background: var(--card-bg);
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: var(--shadow);
+    margin: 0 auto 20px;
+    max-width: 600px;
+}
+
+#giveaway-list {
+    list-style: disc inside;
+    margin-left: 20px;
+}
+
+#giveaway-entry {
+    display: flex;
+    gap: 10px;
+    margin-top: 15px;
 }
 .gfm-card {
     background: #fff;


### PR DESCRIPTION
## Summary
- add Sponsor Finder section with request form and giveaway entry
- style sponsor request UI and integrate with existing sections
- add JavaScript logic to suggest sponsors, draft messages, and handle giveaway entries

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c51ac6f84c832da311664714b01e2c